### PR TITLE
Fixing EXTRACTOR_CISCO_SW_SYSLOG_MNEMONIC_FIRSTPART

### DIFF
--- a/Cisco_Switches_and_Routers.json
+++ b/Cisco_Switches_and_Routers.json
@@ -1072,7 +1072,7 @@
             },
             "source_field": {
               "@type": "string",
-              "@value": "full_message"
+              "@value": "message"
             },
             "title": {
               "@type": "string",


### PR DESCRIPTION
When the real source contains '-' character, the grok pattern use it instead of the CISCO MNEMONIC Part